### PR TITLE
Rudimentary `.gitignore` suitable for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Build Sphinx docs in formats like HTML or PDF
+/docs/_build
+
+# robots.txt is generated automatically by docs.sh
+/docs/_static/robots.txt
+
+# Precompiled Python bytecode
+__pycache__
+*.pyc
+
+# OS-specific local cache files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
While [converting the repository for the translation bot](https://forum.soliditylang.org/t/introducing-the-translations-pr-bot/1115) today, I noticed that the repository contained a lot of files that are not suitable for git versioning. I removed them but to ensure that they won't be committed again, the repository should have a `.gitignore` file. This file tells git to hide these files when making a commit. This PR adds such a file.